### PR TITLE
fix: Makefile を実際のリポジトリ構成に合わせて修正

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,21 +1,26 @@
-DOTFILES_GITHUB   := 'git@github.com:hiroppy/dotfiles.git'
-DOTFILES_EXCLUDES := .DS_Store .git .gitignore .editorconfig
+DOTFILES_EXCLUDES := .DS_Store .git .gitignore .claude .vscode
 DOTFILES_TARGET   := $(wildcard .??*)
 DOTFILES_DIR      := $(PWD)
 DOTFILES_FILES    := $(filter-out $(DOTFILES_EXCLUDES), $(DOTFILES_TARGET))
 
 .PHONY: setup
-setup: brew install fish
+setup: brew install
 
 .PHONY: brew
 brew:
-	/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
+	@command -v brew >/dev/null 2>&1 || /bin/bash -c "$$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 	brew bundle
 
 .PHONY: install
 install:
-	echo 'Start deploy dotfiles current directory.'
-	mkdir -p ~/.config
-	ln -sfnv ~/dotfiles/config/nvim ~/.config/nvim
-	ln -sfnv ~/dotfiles/config/fish ~/.config/fish
+	@echo 'Start deploying dotfiles to home directory.'
 	@$(foreach val, $(DOTFILES_FILES), ln -sfnv $(abspath $(val)) $(HOME)/$(val);)
+
+.PHONY: list
+list:
+	@$(foreach val, $(DOTFILES_FILES), echo $(val);)
+
+.PHONY: clean
+clean:
+	@echo 'Removing symlinks from home directory.'
+	@$(foreach val, $(DOTFILES_FILES), rm -vf $(HOME)/$(val);)

--- a/restore_brew.sh
+++ b/restore_brew.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 # brewをリストア
-/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)" </dev/null
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 brew bundle install --file=.brewfile


### PR DESCRIPTION
## Summary

- Makefile が別リポジトリ (`hiroppy/dotfiles`) の構成を前提としており、そのままでは正しく動作しない状態だったため修正しました
- `restore_brew.sh` の Homebrew インストール URL も同様に古かったため合わせて更新しました

## 変更内容

- **`DOTFILES_GITHUB` の削除**: `hiroppy/dotfiles` を指していた変数を削除
- **存在しないディレクトリへの参照を削除**: `config/nvim`, `config/fish` へのシンボリックリンク作成を削除
- **存在しない `fish` ターゲットへの依存を削除**: `setup` ターゲットが `brew install` のみに依存するよう変更
- **Homebrew インストール URL を更新**: `master` → `HEAD`（Homebrew 公式の推奨に合わせて）
- **brew の重複インストール防止**: 既にインストール済みの場合はスキップ
- **`list` ターゲットを追加**: シンボリックリンク対象のファイル一覧を確認可能に
- **`clean` ターゲットを追加**: ホームディレクトリからシンボリックリンクを削除可能に
- **`restore_brew.sh` も修正**: 同様に古い Homebrew インストール URL を更新

## Test plan

- [ ] `make list` でシンボリックリンク対象のファイル一覧が表示されること
- [ ] `make install` でホームディレクトリにシンボリックリンクが作成されること
- [ ] `make clean` でシンボリックリンクが削除されること

https://claude.ai/code/session_01CqJJMStajdb7YoeLWm6RAb