### PR TITLE
fix: Makefile を実際のリポジトリ構成に合わせて修正

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,7 +1,5 @@
 tap "github/gh"
 tap "homebrew/bundle"
-tap "homebrew/cask"
-tap "homebrew/core"
 tap "homebrew/services"
 tap "mongodb/brew"
 brew "asdf"

--- a/Makefile
+++ b/Makefile
@@ -1,21 +1,36 @@
-DOTFILES_GITHUB   := 'git@github.com:hiroppy/dotfiles.git'
-DOTFILES_EXCLUDES := .DS_Store .git .gitignore .editorconfig
+DOTFILES_GITHUB   := git@github.com:mmmommm/dotfiles.git
+DOTFILES_EXCLUDES := .DS_Store .git .gitignore .claude .vscode
 DOTFILES_TARGET   := $(wildcard .??*)
 DOTFILES_DIR      := $(PWD)
 DOTFILES_FILES    := $(filter-out $(DOTFILES_EXCLUDES), $(DOTFILES_TARGET))
 
 .PHONY: setup
-setup: brew install fish
+setup: brew install
 
 .PHONY: brew
 brew:
-	/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
+	/bin/bash -c "$$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 	brew bundle
 
 .PHONY: install
 install:
-	echo 'Start deploy dotfiles current directory.'
-	mkdir -p ~/.config
-	ln -sfnv ~/dotfiles/config/nvim ~/.config/nvim
-	ln -sfnv ~/dotfiles/config/fish ~/.config/fish
+	@echo 'Start deploying dotfiles to home directory.'
 	@$(foreach val, $(DOTFILES_FILES), ln -sfnv $(abspath $(val)) $(HOME)/$(val);)
+
+.PHONY: prezto
+prezto:
+	git clone --recursive https://github.com/sorin-ionescu/prezto.git "$${ZDOTDIR:-$$HOME}/.zprezto"
+
+.PHONY: backup
+backup:
+	brew bundle dump --file=Brewfile --force
+
+.PHONY: help
+help:
+	@echo 'Available targets:'
+	@echo '  setup   - Install Homebrew, packages, and deploy dotfiles'
+	@echo '  brew    - Install Homebrew and run brew bundle'
+	@echo '  install - Symlink dotfiles to home directory'
+	@echo '  prezto  - Install Prezto (Zsh framework)'
+	@echo '  backup  - Export current Homebrew packages to Brewfile'
+	@echo '  help    - Show this help message'

--- a/setup.sh
+++ b/setup.sh
@@ -6,9 +6,8 @@ do
   [[ "$f" == ".git" ]] && continue
   [[ "$f" == ".DS_Store" ]] && continue
   [[ "$f" == ".brewfile" ]] && continue
-  [[ "$f" = ".git" ]] && continue
-  [[ "$f" = ".gitconfig.local.template" ]] && continue
-  [[ "$f" = ".gitmodules" ]] && continue
+  [[ "$f" == ".gitconfig.local.template" ]] && continue
+  [[ "$f" == ".gitmodules" ]] && continue
 
   echo "$f"
   # 既に貼られている symlink を削除


### PR DESCRIPTION
## Summary

Makefile が別リポジトリ（hiroppy/dotfiles）からコピーされたままになっており、実際のリポジトリ構成と整合していなかったため修正しました。

### 変更内容

- **Makefile**
  - `DOTFILES_GITHUB` を `hiroppy/dotfiles` → `mmmommm/dotfiles` に修正
  - 存在しない `fish` ターゲット依存と `config/nvim`, `config/fish` へのシンボリックリンクを削除
  - Homebrew インストーラー URL を廃止済みの `master` から `HEAD` に更新
  - `.claude`, `.vscode` を除外リストに追加
  - `prezto`（Zsh フレームワークのインストール）、`backup`（Brewfile エクスポート）、`help` ターゲットを追加
- **Brewfile**
  - 非推奨の `homebrew/cask`, `homebrew/core` tap を削除（2023年に廃止済み）
- **setup.sh**
  - 重複した `.git` チェックを削除
  - `=` 演算子を `==` に統一

## Test plan

- [ ] `make help` で利用可能なターゲット一覧が表示されること
- [ ] `make install` でドットファイルが正しくシンボリックリンクされること
- [ ] `brew bundle --file=Brewfile check` で Brewfile が有効であること

https://claude.ai/code/session_01B2dv3iiS5hqh8fFSSQmE5N