### PR TITLE
git completion スクリプトのセットアップを自動化

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ DOTFILES_DIR      := $(PWD)
 DOTFILES_FILES    := $(filter-out $(DOTFILES_EXCLUDES), $(DOTFILES_TARGET))
 
 .PHONY: setup
-setup: brew install
+setup: brew install git-completion
 
 .PHONY: brew
 brew:
@@ -26,6 +26,17 @@ clean:
 	@echo 'Removing symlinks from home directory.'
 	@$(foreach val, $(DOTFILES_FILES), rm -vf $(HOME)/$(val);)
 
+GIT_COMPLETION_BASE_URL := https://raw.githubusercontent.com/git/git/master/contrib/completion
+
+.PHONY: git-completion
+git-completion:
+	@echo 'Setting up git completion scripts.'
+	@mkdir -p $(HOME)/.zsh
+	@curl -sfL -o $(HOME)/.zsh/git-prompt.sh $(GIT_COMPLETION_BASE_URL)/git-prompt.sh
+	@curl -sfL -o $(HOME)/.zsh/git-completion.bash $(GIT_COMPLETION_BASE_URL)/git-completion.bash
+	@curl -sfL -o $(HOME)/.zsh/_git $(GIT_COMPLETION_BASE_URL)/git-completion.zsh
+	@echo 'Git completion scripts installed to ~/.zsh/'
+
 .PHONY: prezto
 prezto:
 	git clone --recursive https://github.com/sorin-ionescu/prezto.git "$${ZDOTDIR:-$$HOME}/.zprezto"
@@ -42,6 +53,7 @@ help:
 	@echo '  install - Symlink dotfiles to home directory'
 	@echo '  list    - List dotfiles that will be symlinked'
 	@echo '  clean   - Remove symlinks from home directory'
+	@echo '  git-completion - Download git completion/prompt scripts to ~/.zsh/'
 	@echo '  prezto  - Install Prezto (Zsh framework)'
 	@echo '  backup  - Export current Homebrew packages to Brewfile'
 	@echo '  help    - Show this help message'

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ make setup
 1. Homebrew がなければインストール
 2. `Brewfile` に記載されたパッケージをインストール (`brew bundle`)
 3. dotfiles をホームディレクトリにシンボリックリンクで配置
+4. git completion / prompt スクリプトを `~/.zsh/` にダウンロード
 
 ### Make targets
 
@@ -26,6 +27,7 @@ make setup
 | `make clean` | ホームディレクトリのシンボリックリンクを削除 |
 | `make prezto` | Prezto (Zsh フレームワーク) のインストール |
 | `make backup` | 現在インストールされている Homebrew パッケージを `Brewfile` にエクスポート |
+| `make git-completion` | git completion / prompt スクリプトを `~/.zsh/` にダウンロード |
 | `make list` | シンボリックリンク対象の dotfiles を一覧表示 |
 | `make help` | 利用可能なコマンド一覧を表示 |
 
@@ -69,18 +71,8 @@ $ ./all.bash
 ```
 
 ## その他使用しているもののインストール
-- [これ](https://qiita.com/mikan3rd/items/d41a8ca26523f950ea9d#pencil2-git-prompt--git-prompt-%E3%81%AE%E7%94%A8%E6%84%8F)
-にそって `git completion zsh` の設定をする
+- git completion / prompt スクリプトは `make setup` (または `make git-completion`) で自動的にインストールされます
 - [これ](https://eng-blog.iij.ad.jp/archives/19131)にそって `kube-ps1` の設定をする
 - [これ](https://www.canva.com/design/DAFGYeHVyzA/9Xgj4-HZAF02UXHm7ol_FQ/view)にそって `raycast` の設定をする
   - my schedule (apple login してカレンダー紐付け)
   - clipboard history に cmd + shift + c でホットキー設定
-
-```terminal
-mkdir ~/.zsh
-cd ~/.zsh
-
-curl -o git-prompt.sh https://raw.githubusercontent.com/git/git/master/contrib/completion/git-prompt.sh
-curl -o git-completion.bash https://raw.githubusercontent.com/git/git/master/contrib/completion/git-completion.bash
-curl -o _git https://raw.githubusercontent.com/git/git/master/contrib/completion/git-completion.zsh
-```


### PR DESCRIPTION
.zshrc で参照している git-prompt.sh, git-completion.bash, _git を make setup 時に自動でダウンロードする git-completion ターゲットを追加。
README の手動 curl 手順を削除し、自動化済みである旨に更新。

https://claude.ai/code/session_016qyeD2g3AiNJvaeDJi9xCn