### PR TITLE
fix: Brewfile ファイル名の不整合を修正

### DIFF
--- a/backup_brew.sh
+++ b/backup_brew.sh
@@ -1,3 +1,4 @@
-#! /bin/bash
-rm .brewfile
-brew bundle dump --file=.brewfile
+#!/bin/bash
+
+# Export currently installed Homebrew packages to Brewfile
+brew bundle dump --file=Brewfile --force

--- a/restore_brew.sh
+++ b/restore_brew.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-# brewをリストア
+# Restore Homebrew and install packages from Brewfile
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-brew bundle install --file=.brewfile
+brew bundle install --file=Brewfile

--- a/setup.sh
+++ b/setup.sh
@@ -5,7 +5,6 @@ for f in .??*
 do
   [[ "$f" == ".git" ]] && continue
   [[ "$f" == ".DS_Store" ]] && continue
-  [[ "$f" == ".brewfile" ]] && continue
   [[ "$f" == ".gitconfig.local.template" ]] && continue
   [[ "$f" == ".gitmodules" ]] && continue
 


### PR DESCRIPTION
## Summary

`backup_brew.sh` と `restore_brew.sh` が `.brewfile` を参照していましたが、Makefile や実際のリポジトリ内のファイルは `Brewfile` を使用しており、ファイル名に不整合がありました。

この不整合により、以下の問題が発生していました:
- `backup_brew.sh` を実行すると `.brewfile` に出力されるが、`make brew` は `Brewfile` を読むため、バックアップが反映されない
- `restore_brew.sh` は `.brewfile` を読もうとするが、リポジトリには `Brewfile` しか存在しないためリストアに失敗する

## Changes

- **`backup_brew.sh`**: `.brewfile` → `Brewfile` に変更。`rm` の代わりに `--force` フラグで上書きするように改善
- **`restore_brew.sh`**: `.brewfile` → `Brewfile` に変更
- **`setup.sh`**: 存在しない `.brewfile` の除外条件を削除

## Test plan

- [ ] `backup_brew.sh` を実行して `Brewfile` が正しく更新されることを確認
- [ ] `restore_brew.sh` を実行して `Brewfile` からパッケージが正しくインストールされることを確認
- [ ] `make backup` と `backup_brew.sh` の出力先が同じ `Brewfile` であることを確認

https://claude.ai/code/session_01Q8rha1LUGSaXEQPEUartsi