### PR TITLE
fix: Brewfile 名の不整合を修正し、スクリプトを改善

### DIFF
--- a/backup_brew.sh
+++ b/backup_brew.sh
@@ -1,3 +1,4 @@
-#! /bin/bash
-rm .brewfile
-brew bundle dump --file=.brewfile
+#!/bin/bash
+
+# Back up current Homebrew packages to Brewfile
+brew bundle dump --file=Brewfile --force

--- a/restore_brew.sh
+++ b/restore_brew.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
-# brewをリストア
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-brew bundle install --file=.brewfile
+# Install Homebrew if not already installed
+command -v brew >/dev/null 2>&1 || /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+# Restore packages from Brewfile
+brew bundle install --file=Brewfile


### PR DESCRIPTION
## Summary

`backup_brew.sh` と `restore_brew.sh` が `.brewfile` を参照していましたが、Makefile や README では `Brewfile` を使用しており、ファイル名に不整合がありました。これにより `backup_brew.sh` でバックアップしたファイルを `make brew` でリストアできない、またはその逆のケースが発生していました。

### 変更内容

- **ファイル名の統一**: `.brewfile` → `Brewfile` に変更し、Makefile・README と整合性を確保
- **backup_brew.sh の改善**:
  - 安全でない `rm .brewfile`（ファイルが存在しない場合エラー）を削除し、`--force` フラグで上書きする方式に変更
  - shebang の余分なスペースを修正 (`#! /bin/bash` → `#!/bin/bash`)
- **restore_brew.sh の改善**:
  - Homebrew が既にインストール済みの場合はインストールをスキップする条件を追加（`command -v brew`）
  - Makefile の `brew` ターゲットと同じ安全なパターンに統一

## Test plan

- [ ] `backup_brew.sh` を実行して `Brewfile` が生成されることを確認
- [ ] `make backup` の出力と `backup_brew.sh` の出力が同じ `Brewfile` を対象にしていることを確認
- [ ] `restore_brew.sh` で `Brewfile` からパッケージがリストアされることを確認
- [ ] Homebrew がインストール済みの環境で `restore_brew.sh` が不要な再インストールをスキップすることを確認

https://claude.ai/code/session_01DMe382MZjZfwNk4faxH3XZ