### PR TITLE
Remove redundant backup_brew.sh and restore_brew.sh

### DIFF
--- a/backup_brew.sh
+++ b/backup_brew.sh
@@ -1,3 +1,0 @@
-#! /bin/bash
-rm .brewfile
-brew bundle dump --file=.brewfile

--- a/restore_brew.sh
+++ b/restore_brew.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-# brewをリストア
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-brew bundle install --file=.brewfile

--- a/setup.sh
+++ b/setup.sh
@@ -5,7 +5,6 @@ for f in .??*
 do
   [[ "$f" == ".git" ]] && continue
   [[ "$f" == ".DS_Store" ]] && continue
-  [[ "$f" == ".brewfile" ]] && continue
   [[ "$f" == ".gitconfig.local.template" ]] && continue
   [[ "$f" == ".gitmodules" ]] && continue
 


### PR DESCRIPTION
## Summary

- `backup_brew.sh` と `restore_brew.sh` を削除（Makefile ターゲットと重複しており、かつファイル名が不整合）
- `setup.sh` から不要になった `.brewfile` の除外条件を削除

## 背景

`backup_brew.sh` と `restore_brew.sh` は `.brewfile` というファイル名を使用していますが、`Makefile` では `Brewfile` を使用しており、ファイル名が不整合でした。

また、これらのスクリプトの機能は既に Makefile のターゲットで完全にカバーされています:

| 削除するスクリプト | 代替の Makefile ターゲット |
|---|---|
| `backup_brew.sh` | `make backup` |
| `restore_brew.sh` | `make brew` |

Makefile 側のターゲットはファイル名が正しく (`Brewfile`)、エラーハンドリングも適切に行われています（`--force` フラグ、brew の存在チェックなど）。

## Test plan

- [ ] `make backup` が正常に `Brewfile` をエクスポートすることを確認
- [ ] `make brew` が正常にパッケージをインストールすることを確認
- [ ] `setup.sh` がドットファイルのシンボリックリンクを正しく作成することを確認

https://claude.ai/code/session_01QDVQhMwD4NP7YVWUvmRYVx