### PR TITLE
chore: Makefile と重複する brew スクリプトを削除

### DIFF
--- a/backup_brew.sh
+++ b/backup_brew.sh
@@ -1,3 +1,0 @@
-#! /bin/bash
-rm .brewfile
-brew bundle dump --file=.brewfile

--- a/restore_brew.sh
+++ b/restore_brew.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-# brewをリストア
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-brew bundle install --file=.brewfile

--- a/setup.sh
+++ b/setup.sh
@@ -5,7 +5,6 @@ for f in .??*
 do
   [[ "$f" == ".git" ]] && continue
   [[ "$f" == ".DS_Store" ]] && continue
-  [[ "$f" == ".brewfile" ]] && continue
   [[ "$f" == ".gitconfig.local.template" ]] && continue
   [[ "$f" == ".gitmodules" ]] && continue
 


### PR DESCRIPTION
## Summary

- `backup_brew.sh` と `restore_brew.sh` を削除
- `setup.sh` から不要になった `.brewfile` の除外行を削除

## 背景

`backup_brew.sh` / `restore_brew.sh` は `.brewfile`（ドット付き）を使用していましたが、Makefile の `make backup` / `make brew` は `Brewfile`（ドットなし）を使用しており、ファイル名に不整合がありました。

| 操作 | 旧スクリプト | Makefile |
|---|---|---|
| バックアップ | `backup_brew.sh` → `.brewfile` | `make backup` → `Brewfile` |
| リストア | `restore_brew.sh` → `.brewfile` | `make brew` → `Brewfile` |

Makefile に同等の機能が既にあるため、混乱を避けるために旧スクリプトを削除します。

## Test plan

- [ ] `make backup` で Brewfile へのエクスポートが正常に動作すること
- [ ] `make brew` で Brewfile からのインストールが正常に動作すること
- [ ] `make setup` が正常に完了すること

https://claude.ai/code/session_01NvafQxDo6Cg74vhSYWE92N