### PR TITLE
docs: .gitmessage にコミットメッセージテンプレートを追加

### DIFF
--- a/.gitmessage
+++ b/.gitmessage
@@ -1,5 +1,5 @@
 
-# <type>: <subject>
+# <type>(<scope>): <subject>
 #
 # <body>
 #
@@ -13,8 +13,8 @@
 # refactor: A code change that neither fixes a bug nor adds a feature
 # perf:     A code change that improves performance
 # test:     Adding missing or correcting existing tests
-# chore:    Changes to the build process or auxiliary tools
 # ci:       Changes to CI configuration files and scripts
+# chore:    Changes to the build process or auxiliary tools
 #
 # --- Rules ---
 # - Subject: imperative mood, no period, max 50 chars

--- a/.gitmessage
+++ b/.gitmessage
@@ -1,0 +1,22 @@
+
+# <type>: <subject>
+#
+# <body>
+#
+# <footer>
+#
+# --- Type ---
+# feat:     A new feature
+# fix:      A bug fix
+# docs:     Documentation only changes
+# style:    Changes that do not affect the meaning of the code
+# refactor: A code change that neither fixes a bug nor adds a feature
+# perf:     A code change that improves performance
+# test:     Adding missing or correcting existing tests
+# chore:    Changes to the build process or auxiliary tools
+# ci:       Changes to CI configuration files and scripts
+#
+# --- Rules ---
+# - Subject: imperative mood, no period, max 50 chars
+# - Body:    explain *what* and *why*, not *how* (wrap at 72 chars)
+# - Footer:  reference issues (e.g. Closes #123)

--- a/README.md
+++ b/README.md
@@ -70,6 +70,17 @@ $ git checkout <tag>
 $ ./all.bash
 ```
 
+## Git コミットメッセージテンプレート
+
+`.gitmessage` に [Conventional Commits](https://www.conventionalcommits.org/) ベースのテンプレートが設定されています。
+`git commit` を実行するとエディタにテンプレートが表示されるので、type・scope・subject を埋めてコミットメッセージを作成してください。
+
+```
+<type>(<scope>): <subject>
+```
+
+利用可能な type: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `ci`, `chore`
+
 ## その他使用しているもののインストール
 - git completion / prompt スクリプトは `make setup` (または `make git-completion`) で自動的にインストールされます
 - [これ](https://eng-blog.iij.ad.jp/archives/19131)にそって `kube-ps1` の設定をする


### PR DESCRIPTION
## Summary

- `.gitconfig` で `commit.template = ~/.gitmessage` が設定されているが、`.gitmessage` が空だったため、Conventional Commits ベースのテンプレートを追加
- `git commit` 実行時にエディタへテンプレートが表示され、type・scope・subject の記入ガイドとして機能します
- README.md にテンプレートの使い方セクションを追加

## 変更内容

- **`.gitmessage`**: `feat`, `fix`, `docs` 等の type 一覧と、subject / body / footer のルールをコメントで記載。scope 付きフォーマット `<type>(<scope>): <subject>` を採用
- **`README.md`**: 「Git コミットメッセージテンプレート」セクションを追加し、Conventional Commits へのリンクと利用可能な type の一覧を記載

## 背景

このリポジトリのコミット履歴を見ると `fix:` や `docs:` などの Conventional Commits プレフィックスが一部使われていますが、統一されていません。テンプレートを追加することで、コミット時に毎回フォーマットを確認でき、一貫したコミットメッセージを書きやすくなります。

## Test plan

- [ ] `git commit` を実行し、エディタにテンプレートが表示されることを確認
- [ ] コメント行（`#` で始まる行）がコミットメッセージに含まれないことを確認
- [ ] README の新セクションが正しく表示されることを確認

https://claude.ai/code/session_01M7Wm45HkitPbhkfaWQedYf