### PR TITLE
fix: tmux.conf から非推奨の reattach-to-user-namespace と重複設定を削除

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -8,9 +8,7 @@ set -g prefix C-q
 # set-option -g status-utf8 on
 set -g mouse on
 
-# https://github.com/tmux/tmux/issues/543
 set -g default-shell /bin/zsh
-set -g default-command "reattach-to-user-namespace -l ${SHELL}"
 
 # copy mode でのキーバインドを vi にする
 # Ctrl + q + [ でコピーモードに入る
@@ -86,6 +84,4 @@ bind -T copy-mode-vi Enter send-keys -X copy-pipe-and-cancel "pbcopy"
 
 # set-option and bind set
 
-# マウス操作を有効にする
-set-option -g mouse on
 bind -n WheelUpPane if-shell -F -t = "#{mouse_any_flag}" "send-keys -M" "if -Ft= '#{pane_in_mode}' 'send-keys -M' 'copy-mode -e'"


### PR DESCRIPTION
## Summary

- `reattach-to-user-namespace` の `default-command` 設定を削除
- 重複していた `set -g mouse on`（9行目と90行目）を一箇所に統一

## 背景

### reattach-to-user-namespace の削除

`reattach-to-user-namespace` は、古い macOS + tmux 環境でクリップボード連携やシェル起動に問題があった際の回避策です（[tmux/tmux#543](https://github.com/tmux/tmux/issues/543)）。

**tmux 2.6（2017年リリース）以降、この問題は修正済み**のため不要になっています。さらに、`reattach-to-user-namespace` が Brewfile に含まれていないため、新規マシンで `make setup` を実行すると tmux 起動時にエラーが発生します。

### mouse on の重複削除

`set -g mouse on` が9行目と90行目に重複して記述されていたため、9行目の設定のみに統一しました。

## Test plan

- [ ] tmux を起動してシェルが正常に動作すること
- [ ] コピーモード（Ctrl-q + [）でクリップボードへのコピーが動作すること
- [ ] マウス操作（スクロール、ペイン選択）が動作すること

https://claude.ai/code/session_01WVNx3xoZLyM6GizsHWVGVA