### PR TITLE
fix: bin/ 配下のシェルスクリプトを堅牢化

### DIFF
--- a/bin/copy-all-dotfiles.sh
+++ b/bin/copy-all-dotfiles.sh
@@ -1,8 +1,33 @@
-#!/bin/bash -e
-ls -a | grep -Ev "README|bin|\.$|^\.git$" | while read f; do
-  if [ $f = ".ssh_config"  ]; then
-    cp $f $HOME/.ssh/config
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+EXCLUDES=(.git .gitignore .claude .vscode .DS_Store README.md Makefile bin)
+
+cd "$SCRIPT_DIR"
+
+should_exclude() {
+  local file="$1"
+  for exc in "${EXCLUDES[@]}"; do
+    if [ "$file" = "$exc" ]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+for f in .??* *; do
+  [ "$f" = ".??*" ] && continue
+  should_exclude "$f" && continue
+
+  if [ "$f" = ".ssh_config" ]; then
+    mkdir -p "$HOME/.ssh"
+    cp "$f" "$HOME/.ssh/config"
+    echo "  $f -> ~/.ssh/config"
   else
-   cp $f $HOME/
+    cp -r "$f" "$HOME/"
+    echo "  $f -> ~/$f"
   fi
-done  
+done
+
+echo "Done."

--- a/bin/copy-claude-files.sh
+++ b/bin/copy-claude-files.sh
@@ -1,17 +1,19 @@
-#!/bin/bash -e
+#!/bin/bash
+set -euo pipefail
 
-# .claude ディレクトリが存在するか確認
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$SCRIPT_DIR"
+
 if [ ! -d ".claude" ]; then
-  echo "Error: .claude directory not found in the current directory"
+  echo "Error: .claude directory not found in $(pwd)"
   exit 1
 fi
 
 # ~/.claude ディレクトリを作成（存在しない場合）
 mkdir -p "$HOME/.claude"
 
-# .claude 配下のすべてのファイルとディレクトリを再帰的にコピー
-echo "Copying .claude files to ~/.claude..."
+echo "Copying .claude files to ~/.claude/..."
 cp -rv .claude/* "$HOME/.claude/" 2>&1 | sed 's/^/  /' | grep -v "^  .claude/\." || true
 
 echo ""
-echo "Claude files copied successfully to ~/.claude/"
+echo "Done."

--- a/bin/pull-claude-files.sh
+++ b/bin/pull-claude-files.sh
@@ -1,12 +1,14 @@
-#!/bin/bash -e
+#!/bin/bash
+set -euo pipefail
 
-# ~/.claude ディレクトリが存在するか確認
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$SCRIPT_DIR"
+
 if [ ! -d "$HOME/.claude" ]; then
   echo "Error: ~/.claude directory not found"
   exit 1
 fi
 
-# .claude ディレクトリを作成（存在しない場合）
 mkdir -p ".claude"
 
 # CLAUDE.md をコピー
@@ -21,12 +23,11 @@ if [ -f "$HOME/.claude/settings.json" ]; then
   cp -v "$HOME/.claude/settings.json" ".claude/" 2>&1 | sed 's/^/  /'
 fi
 
-# commands ディレクトリをコピー
 if [ -d "$HOME/.claude/commands" ]; then
   echo "Copying ~/.claude/commands/..."
   mkdir -p ".claude/commands"
-  cp -rv "$HOME/.claude/commands/"* ".claude/commands/" 2>&1 | sed 's/^/  /' | grep -v "^  $HOME/.claude/commands/\." || true
+  cp -rv "$HOME/.claude/commands/"* ".claude/commands/" 2>&1 | sed 's/^/  /' || true
 fi
 
 echo ""
-echo "Claude files pulled successfully from ~/.claude/"
+echo "Done."


### PR DESCRIPTION
# Summary

`bin/` 配下の3つのシェルスクリプトを堅牢化しました。

## 変更内容

### copy-all-dotfiles.sh（主な修正）
- **`ls` 出力のパースを廃止**: `ls -a | grep | while read` というアンチパターンを glob ベースの `for` ループに置き換え
- **変数のクォート**: `$f` → `"$f"` でスペースを含むファイル名での誤動作を防止
- **`~/.ssh` ディレクトリの自動作成**: `.ssh_config` コピー時に `mkdir -p` を追加
- **除外対象を Makefile と統一**: `.claude`, `.vscode`, `.DS_Store` を除外リストに追加

### 全スクリプト共通
- `#!/bin/bash -e` → `set -euo pipefail` に変更（未定義変数やパイプラインのエラーも検知）
- `SCRIPT_DIR` を使い、どこから実行してもリポジトリルートを基準に動作するよう修正
- 冗長なコメントを削除

## Before / After

**Before** (`copy-all-dotfiles.sh`):
```bash
#!/bin/bash -e
ls -a | grep -Ev "README|bin|\.$|^\.git$" | while read f; do
  if [ $f = ".ssh_config"  ]; then
    cp $f $HOME/.ssh/config
  else
   cp $f $HOME/
  fi
done
```

**After**:
```bash
#!/bin/bash
set -euo pipefail
SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
EXCLUDES=(.git .gitignore .claude .vscode .DS_Store README.md Makefile bin)
cd "$SCRIPT_DIR"
# ... glob-based loop with proper quoting
```

## Test plan
- [ ] `bin/copy-all-dotfiles.sh` を実行し、dotfiles が正しく `~/` にコピーされることを確認
- [ ] `bin/copy-claude-files.sh` を実行し、`.claude/` 配下が `~/.claude/` にコピーされることを確認
- [ ] `bin/pull-claude-files.sh` を実行し、`~/.claude/` から `.claude/` にファイルが取り込まれることを確認
- [ ] リポジトリルート以外のディレクトリから各スクリプトを実行しても正しく動作することを確認

https://claude.ai/code/session_014VsRr6pVAwAu7Kxa5YRD8F

---
_Generated by [Claude Code](https://claude.ai/code/session_014VsRr6pVAwAu7Kxa5YRD8F)_