### PR TITLE
fix: .zshrc で未インストールのコマンドにガード条件を追加

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -22,11 +22,12 @@ export PATH="$HOME/.local/bin:$PATH"
 # Go
 export GOPRIVATE="github.com/cycloud-io,github.com/CyberAgent,github.com/mmmommm"
 export GOROOT=/usr/local/go
-# export GOPATH=$HOME/go
 export PATH=$PATH:/usr/local/go/bin
 export GO111MODULE=on
-export GOBIN=$(go env GOPATH)/bin
-export PATH=$PATH:$GOBIN
+if command -v go >/dev/null 2>&1; then
+  export GOBIN=$(go env GOPATH)/bin
+  export PATH=$PATH:$GOBIN
+fi
 export GOPROXY="https://proxy.golang.org,direct"
 export GOSUMDB="sum.golang.org"
 
@@ -44,8 +45,10 @@ export PATH="$CARGO_HOME/bin:$PATH"
 # Python Pyenv
 export PYENV_ROOT="$HOME/.pyenv"
 export PATH="$PYENV_ROOT/bin:$PATH"
-eval "$(pyenv init --path)"
-eval "$(pyenv init -)"
+if command -v pyenv >/dev/null 2>&1; then
+  eval "$(pyenv init --path)"
+  eval "$(pyenv init -)"
+fi
 export PATH="/.local/bin/ansible:$PATH"
 
 # Docker
@@ -219,10 +222,10 @@ precmd () { vcs_info }
 plugins=(git zsh-syntax-highlighting zsh-completions)
 
 # git の current branch出すやつ
-source ~/.zsh/git-prompt.sh
+[ -f ~/.zsh/git-prompt.sh ] && source ~/.zsh/git-prompt.sh
 # git-completionの読み込み
 fpath=(~/.zsh $fpath)
-zstyle ':completion:*:*:git:*' script ~/.zsh/git-completion.bash
+[ -f ~/.zsh/git-completion.bash ] && zstyle ':completion:*:*:git:*' script ~/.zsh/git-completion.bash
 
 GIT_PS1_SHOWDIRTYSTATE=true
 GIT_PS1_SHOWUNTRACKEDFILES=true
@@ -233,7 +236,9 @@ setopt PROMPT_SUBST
 
 # kubectl の補完を効くようにするやつ
 # https://kubernetes.io/docs/reference/kubectl/generated/kubectl_completion/
-source <(kubectl completion zsh)
+if command -v kubectl >/dev/null 2>&1; then
+  source <(kubectl completion zsh)
+fi
 
 export PS1='%F{green}%n@%m%f: %F{cyan}%~%f %F{red}$(__git_ps1 "(%s)")%f\$ '
 
@@ -244,7 +249,7 @@ if [ -f "$HOME/google-cloud-sdk/path.zsh.inc" ]; then . "$HOME/google-cloud-sdk/
 if [ -f "$HOME/google-cloud-sdk/completion.zsh.inc" ]; then . "$HOME/google-cloud-sdk/completion.zsh.inc"; fi
 
 # asdf
-. /opt/homebrew/opt/asdf/libexec/asdf.sh
+[ -f /opt/homebrew/opt/asdf/libexec/asdf.sh ] && . /opt/homebrew/opt/asdf/libexec/asdf.sh
 
 # bun completions
 [ -s "$HOME/.bun/_bun" ] && source "$HOME/.bun/_bun"
@@ -252,10 +257,6 @@ if [ -f "$HOME/google-cloud-sdk/completion.zsh.inc" ]; then . "$HOME/google-clou
 # bun
 export BUN_INSTALL="$HOME/.bun"
 export PATH="$BUN_INSTALL/bin:$PATH"
-
-# KServe
-export KO_DEFAULTPLATFORMS=linux/arm64
-export KO_DOCKER_REPO="docker.io/$USER_NAME"
 
 # tmux
 # 初回シェル時のみ tmux実行


### PR DESCRIPTION
## Summary

- `go`, `pyenv`, `kubectl` が未インストールの環境でシェル起動時にエラーが出ないよう `command -v` によるガード条件を追加
- `git-prompt.sh`, `git-completion.bash`, `asdf.sh` のファイル読み込みに `[ -f ... ]` の存在チェックを追加
- `KO_DEFAULTPLATFORMS` と `KO_DOCKER_REPO` が `.zshrc` 内で重複定義されていたのを解消（kserve セクション側の定義を残し、末尾の重複を削除）

## 背景

新しいマシンや一部ツールを入れていない環境で `zsh` を起動すると、以下のようなエラーが表示されていました：

- `command not found: go` （`go env GOPATH` の実行）
- `command not found: pyenv`（`pyenv init` の実行）
- `command not found: kubectl`（`kubectl completion zsh` の実行）
- `No such file or directory: /opt/homebrew/opt/asdf/libexec/asdf.sh`
- `No such file or directory: ~/.zsh/git-prompt.sh`（`make git-completion` 実行前）

既に `fzf`, `nvm`, `bun`, `gcloud` などでは同様のガードパターンが使われていたため、それに合わせた形です。

## Test plan

- [ ] 対象ツールがインストールされている環境で `source ~/.zshrc` してエラーが出ないことを確認
- [ ] 対象ツールがインストールされていない環境で `source ~/.zshrc` してエラーが出ないことを確認
- [ ] `go`, `pyenv`, `kubectl` の補完・初期化が正常に動作することを確認

https://claude.ai/code/session_01Kh5K2kkqKnosXLoQASQtBg

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kh5K2kkqKnosXLoQASQtBg)_