### PR TITLE
fix: conda 初期化のハードコードされたパスを $HOME に置換

### DIFF
--- a/.bash_profile
+++ b/.bash_profile
@@ -5,14 +5,14 @@ export PATH="/usr/local/opt/mysql@5.6/bin:$PATH"
 
 # >>> conda initialize >>>
 # !! Contents within this block are managed by 'conda init' !!
-__conda_setup="$('/Users/s14958/miniconda3/bin/conda' 'shell.bash' 'hook' 2> /dev/null)"
+__conda_setup="$("$HOME/miniconda3/bin/conda" 'shell.bash' 'hook' 2> /dev/null)"
 if [ $? -eq 0 ]; then
     eval "$__conda_setup"
 else
-    if [ -f "/Users/s14958/miniconda3/etc/profile.d/conda.sh" ]; then
-        . "/Users/s14958/miniconda3/etc/profile.d/conda.sh"
+    if [ -f "$HOME/miniconda3/etc/profile.d/conda.sh" ]; then
+        . "$HOME/miniconda3/etc/profile.d/conda.sh"
     else
-        export PATH="/Users/s14958/miniconda3/bin:$PATH"
+        export PATH="$HOME/miniconda3/bin:$PATH"
     fi
 fi
 unset __conda_setup

--- a/.zshrc
+++ b/.zshrc
@@ -265,14 +265,14 @@ fi
 
 # >>> conda initialize >>>
 # !! Contents within this block are managed by 'conda init' !!
-__conda_setup="$('/Users/s14958/miniconda3/bin/conda' 'shell.zsh' 'hook' 2> /dev/null)"
+__conda_setup="$("$HOME/miniconda3/bin/conda" 'shell.zsh' 'hook' 2> /dev/null)"
 if [ $? -eq 0 ]; then
     eval "$__conda_setup"
 else
-    if [ -f "/Users/s14958/miniconda3/etc/profile.d/conda.sh" ]; then
-        . "/Users/s14958/miniconda3/etc/profile.d/conda.sh"
+    if [ -f "$HOME/miniconda3/etc/profile.d/conda.sh" ]; then
+        . "$HOME/miniconda3/etc/profile.d/conda.sh"
     else
-        export PATH="/Users/s14958/miniconda3/bin:$PATH"
+        export PATH="$HOME/miniconda3/bin:$PATH"
     fi
 fi
 unset __conda_setup


### PR DESCRIPTION
## Summary

- `.zshrc` と `.bash_profile` の conda initialize ブロックで `/Users/s14958/miniconda3` がハードコードされていたのを `$HOME/miniconda3` に置換
- これにより、異なるユーザー名や異なるマシンでも conda が正しく初期化されるようになります

## 背景

`conda init` コマンドが自動生成するブロックは、実行時のユーザーの絶対パスをそのまま埋め込みます。dotfiles として共有・再利用する場合、この絶対パスは他の環境では存在しないため、conda の初期化に失敗します。

## 変更内容

| ファイル | 変更箇所 |
|---|---|
| `.zshrc` (L268-275) | `/Users/s14958/miniconda3` → `$HOME/miniconda3` |
| `.bash_profile` (L8-15) | `/Users/s14958/miniconda3` → `$HOME/miniconda3` |

## Test plan

- [ ] 変更後の `.zshrc` を source して conda コマンドが正しく動作することを確認
- [ ] 変更後の `.bash_profile` を source して conda コマンドが正しく動作することを確認
- [ ] miniconda3 がインストールされていない環境でもエラーが出ないことを確認（既存の `2> /dev/null` で抑制される）

https://claude.ai/code/session_01CDWBCrS8YG1ethGxeF5zng

---
_Generated by [Claude Code](https://claude.ai/code/session_01CDWBCrS8YG1ethGxeF5zng)_