### PR TITLE
make install 時に既存ファイルを自動バックアップする機能を追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ DOTFILES_EXCLUDES := .DS_Store .git .gitignore .claude .vscode
 DOTFILES_TARGET   := $(wildcard .??*)
 DOTFILES_DIR      := $(PWD)
 DOTFILES_FILES    := $(filter-out $(DOTFILES_EXCLUDES), $(DOTFILES_TARGET))
+BACKUP_DIR        := $(HOME)/.dotfiles_backup/$(shell date +%Y%m%d_%H%M%S)
 
 .PHONY: setup
 setup: brew install git-completion
@@ -15,7 +16,13 @@ brew:
 .PHONY: install
 install:
 	@echo 'Start deploying dotfiles to home directory.'
-	@$(foreach val, $(DOTFILES_FILES), ln -sfnv $(abspath $(val)) $(HOME)/$(val);)
+	@$(foreach val, $(DOTFILES_FILES), \
+		if [ -e $(HOME)/$(val) ] && [ ! -L $(HOME)/$(val) ]; then \
+			mkdir -p $(BACKUP_DIR); \
+			echo 'Backing up $(HOME)/$(val) to $(BACKUP_DIR)/$(val)'; \
+			mv $(HOME)/$(val) $(BACKUP_DIR)/$(val); \
+		fi; \
+		ln -sfnv $(abspath $(val)) $(HOME)/$(val);)
 
 .PHONY: list
 list:
@@ -50,7 +57,7 @@ help:
 	@echo 'Available targets:'
 	@echo '  setup   - Install Homebrew, packages, and deploy dotfiles'
 	@echo '  brew    - Install Homebrew and run brew bundle'
-	@echo '  install - Symlink dotfiles to home directory'
+	@echo '  install - Symlink dotfiles to home directory (backs up existing files)'
 	@echo '  list    - List dotfiles that will be symlinked'
 	@echo '  clean   - Remove symlinks from home directory'
 	@echo '  git-completion - Download git completion/prompt scripts to ~/.zsh/'

--- a/README.md
+++ b/README.md
@@ -33,13 +33,26 @@ make setup
 
 ## Prerequisites
 
-git コマンドがあるかを確認
-`git --version`
+### Xcode Command Line Tools
 
-brew コマンドがあるかを確認
-`brew list`
+`make setup` の実行には Xcode Command Line Tools が必要です。未インストールの場合は以下を実行してください。
 
-それぞれ[ここ](https://tracpath.com/bootcamp/git-install-to-mac.html)を見れば全部できるはず
+```terminal
+xcode-select --install
+```
+
+### 確認
+
+```terminal
+git --version   # git コマンドがあるか確認
+make --version  # make コマンドがあるか確認
+```
+
+> **Note:** Homebrew は `make setup` の中で自動インストールされるため、事前のインストールは不要です。
+
+### dotfiles のバックアップについて
+
+`make install` は既存のファイル（シンボリックリンクではない実ファイル）を `~/.dotfiles_backup/<timestamp>/` に自動でバックアップしてからシンボリックリンクを作成します。既にシンボリックリンクが張られている場合はバックアップなしで上書きされます。
 
 ## Go のインストール
 [go bootstrap](https://go.dev/doc/install/source)でインストール


### PR DESCRIPTION
## Summary

- `make install` 実行時、既存の設定ファイル（シンボリックリンクではない実ファイル）を `~/.dotfiles_backup/<timestamp>/` に自動バックアップしてからシンボリックリンクを作成するように改善
- README の Prerequisites セクションを整理し、Xcode Command Line Tools のインストール手順を明記
- Homebrew が `make setup` で自動インストールされることを Note として追記

## Why

新しい Mac や既に設定ファイルがある環境で `make install` を実行すると、既存の `.zshrc` や `.gitconfig` などがシンボリックリンクで上書きされ、元のファイルが失われるリスクがありました。タイムスタンプ付きのバックアップディレクトリに退避することで、安全にセットアップできるようになります。

## Changes

### Makefile
- `BACKUP_DIR` 変数を追加（`~/.dotfiles_backup/YYYYMMDD_HHMMSS`）
- `install` ターゲットで、シンボリックリンク作成前に既存の実ファイルをバックアップ
- `help` ターゲットの `install` 説明にバックアップについて追記

### README.md
- Prerequisites セクションに Xcode Command Line Tools のインストール手順を追加
- `git` / `make` コマンドの確認方法をコードブロックで整理
- Homebrew 自動インストールの Note を追加
- バックアップ機能の説明セクションを追加

https://claude.ai/code/session_01PYgpcowvcEKEYU8192vJQM

---
_Generated by [Claude Code](https://claude.ai/code/session_01PYgpcowvcEKEYU8192vJQM)_