### PR TITLE
fix: シェル設定のハードコードパスと重複定義を修正

### DIFF
--- a/.bash_profile
+++ b/.bash_profile
@@ -1,18 +1,17 @@
 export PATH="$HOME/.nodebrew/current/bin:$PATH"
 export PATH="/usr/local/opt/protobuf@3.7/bin:$PATH"
 export PATH="/usr/local/opt/mysql@5.6/bin:$PATH"
-export PATH="/usr/local/opt/mysql@5.6/bin:$PATH"
 
 # >>> conda initialize >>>
 # !! Contents within this block are managed by 'conda init' !!
-__conda_setup="$('/Users/s14958/miniconda3/bin/conda' 'shell.bash' 'hook' 2> /dev/null)"
+__conda_setup="$("$HOME/miniconda3/bin/conda" 'shell.bash' 'hook' 2> /dev/null)"
 if [ $? -eq 0 ]; then
     eval "$__conda_setup"
 else
-    if [ -f "/Users/s14958/miniconda3/etc/profile.d/conda.sh" ]; then
-        . "/Users/s14958/miniconda3/etc/profile.d/conda.sh"
+    if [ -f "$HOME/miniconda3/etc/profile.d/conda.sh" ]; then
+        . "$HOME/miniconda3/etc/profile.d/conda.sh"
     else
-        export PATH="/Users/s14958/miniconda3/bin:$PATH"
+        export PATH="$HOME/miniconda3/bin:$PATH"
     fi
 fi
 unset __conda_setup

--- a/.zshrc
+++ b/.zshrc
@@ -253,10 +253,6 @@ if [ -f "$HOME/google-cloud-sdk/completion.zsh.inc" ]; then . "$HOME/google-clou
 export BUN_INSTALL="$HOME/.bun"
 export PATH="$BUN_INSTALL/bin:$PATH"
 
-# KServe
-export KO_DEFAULTPLATFORMS=linux/arm64
-export KO_DOCKER_REPO="docker.io/$USER_NAME"
-
 # tmux
 # 初回シェル時のみ tmux実行
 if [ $SHLVL = 1 ]; then
@@ -265,14 +261,14 @@ fi
 
 # >>> conda initialize >>>
 # !! Contents within this block are managed by 'conda init' !!
-__conda_setup="$('/Users/s14958/miniconda3/bin/conda' 'shell.zsh' 'hook' 2> /dev/null)"
+__conda_setup="$("$HOME/miniconda3/bin/conda" 'shell.zsh' 'hook' 2> /dev/null)"
 if [ $? -eq 0 ]; then
     eval "$__conda_setup"
 else
-    if [ -f "/Users/s14958/miniconda3/etc/profile.d/conda.sh" ]; then
-        . "/Users/s14958/miniconda3/etc/profile.d/conda.sh"
+    if [ -f "$HOME/miniconda3/etc/profile.d/conda.sh" ]; then
+        . "$HOME/miniconda3/etc/profile.d/conda.sh"
     else
-        export PATH="/Users/s14958/miniconda3/bin:$PATH"
+        export PATH="$HOME/miniconda3/bin:$PATH"
     fi
 fi
 unset __conda_setup


### PR DESCRIPTION
## 概要\n\nシェル設定ファイルに含まれるハードコードされたユーザー固有のパスと重複定義を修正し、dotfiles のポータビリティを向上させます。\n\n## 変更内容\n\n### `.zshrc`\n- **重複した KServe 環境変数を削除**: `KO_DEFAULTPLATFORMS` と `KO_DOCKER_REPO` がファイル内で2箇所（L71-72 と L257-258）に定義されていたため、後者を削除\n- **conda 初期化パスを修正**: `/Users/s14958/miniconda3` → `$HOME/miniconda3` に変更し、他の環境でも動作するように\n\n### `.bash_profile`\n- **重複した PATH エントリを削除**: `mysql@5.6` の PATH が2行連続で同一内容だったため、1行に整理\n- **conda 初期化パスを修正**: `/Users/s14958/miniconda3` → `$HOME/miniconda3` に変更\n\n## 背景\n\n- ハードコードされた `/Users/s14958/` パスは特定のマシンでしか動作せず、dotfiles を別環境にクローンした際に conda の初期化が失敗します\n- `$HOME` を使用することで、どのユーザー・環境でも正しく動作するようになります\n- 重複定義は意図しない上書きや混乱の原因となるため整理しました

---
_Generated by [Claude Code](https://claude.ai/code/session_01HmZACQNQhxcaNs7aBVpGTf)_