### PR TITLE
fix: .gitconfig の重複 [color] セクション削除と excludesfile パスを修正

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -5,14 +5,6 @@
 [include]
 	path = .gitconfig_local
 [color]
-	status = auto
-	diff = auto
-	branch = auto
-	interactive = auto
-	grep = auto
-
-[color]
-	# Use colors in Git commands that are capable of colored output when outputting to the terminal
 	ui = auto
 [color "branch"]
 	current = yellow reverse
@@ -63,7 +55,7 @@
 	stsp = stash pop
 	swc = switch -c
 [core]
-	excludesfile = ~/.config/git/ignore
+	excludesfile = ~/.gitignore_global
 [push]
 	default = upstream
 [commit]


### PR DESCRIPTION
## Summary

`.gitconfig` に含まれる2つの問題を修正しました。

### 1. 重複した `[color]` セクションの統合

`[color]` セクションが2箇所に分かれて定義されていました：

```gitconfig
# 1つ目（L7-12）- 個別設定
[color]
    status = auto
    diff = auto
    branch = auto
    interactive = auto
    grep = auto

# 2つ目（L14-16）- 一括設定
[color]
    ui = auto
```

`color.ui = auto` は全てのサブコマンドの色設定を一括で有効にするため、1つ目のセクションの `status`, `diff`, `branch`, `interactive`, `grep` の個別設定は完全に冗長です。2つ目の `ui = auto` に統合しました。

### 2. `core.excludesfile` パスの修正

| 項目 | Before | After |
|---|---|---|
| `core.excludesfile` | `~/.config/git/ignore` | `~/.gitignore_global` |

リポジトリに `.gitignore_global` ファイル（`.DS_Store` と `.idea` を除外）が含まれており、`make install` で `~/.gitignore_global` にシンボリックリンクされます。しかし `.gitconfig` の `excludesfile` は `~/.config/git/ignore` を指しており、リポジトリの `.gitignore_global` が実際には使われていませんでした。

パスを `~/.gitignore_global` に修正することで、`make install` 後にグローバル gitignore が正しく機能するようになります。

## Test plan

- [ ] `git config --get core.excludesfile` で `~/.gitignore_global` が返ることを確認
- [ ] `.DS_Store` や `.idea` が git の追跡対象外になっていることを確認
- [ ] `git config --get color.ui` で `auto` が返ることを確認
- [ ] git の各コマンド（`status`, `diff`, `log` など）で色付き出力が従来通り動作することを確認

https://claude.ai/code/session_01PafRdsXKUGmspAX2zM9ppS

---
_Generated by [Claude Code](https://claude.ai/code/session_01PafRdsXKUGmspAX2zM9ppS)_